### PR TITLE
chore: enforce LF for Pintos helper scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Linux-executed Pintos helper scripts must keep LF line endings.
+pintos/activate text eol=lf
+pintos/utils/* text eol=lf


### PR DESCRIPTION
## Summary
- add .gitattributes
- keep Pintos helper scripts LF for Linux/WSL execution

## Notes
- no Pintos runtime code changes