### PR TITLE
fix: clean up alarm clock wakeup helper

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -147,7 +147,7 @@ timer_interrupt (struct intr_frame *args UNUSED) {
 	/* 이미 INTR_OFF에서 동작하므로 인터럽트 걱정은 하지 않아도 됨 */
 	ticks++;
 	thread_tick ();
-	thread_wakeup(timer_ticks());
+	thread_wakeup(ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -216,7 +216,7 @@ thread_create (const char *name, int priority,
 }
 
 /* tick이 가장 빠른 순서대로 정렬을 위한 함수 (오름차순) */
-bool
+static bool
 wakeup_recently (const struct list_elem *a,
                const struct list_elem *b,
                void *aux UNUSED)


### PR DESCRIPTION
## Summary

- \wakeup_recently()\를 \	hread.c\ 내부 전용 helper로 명확히 하기 위해 \static\으로 변경했습니다.
- timer interrupt handler에서 이미 증가된 전역 \	icks\ 값을 직접 \	hread_wakeup()\에 전달하도록 정리했습니다.

## Changes

- \pintos/threads/thread.c\`n  - sleep list 정렬 비교 함수 \wakeup_recently()\에 \static\ 지정
  - 불필요한 전역 함수 노출 및 \-Wmissing-prototypes\ 경고 가능성 제거

- \pintos/devices/timer.c\`n  - \	hread_wakeup(timer_ticks())\ 대신 \	hread_wakeup(ticks)\ 사용
  - 인터럽트 컨텍스트에서 불필요한 \	imer_ticks()\ 호출 제거

## Test

- Not run