### PR TITLE
fix: make devcontainer source pintos activate generically

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,9 @@ RUN echo "jungle ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jungle
 USER jungle
 WORKDIR /home/jungle
 
-RUN echo "source /workspaces/pintos_22.04_lab_docker/pintos/activate" >> /home/jungle/.bashrc
+# Original lab path kept for reference:
+# RUN echo "source /workspaces/pintos_22.04_lab_docker/pintos/activate" >> /home/jungle/.bashrc
+RUN echo 'for activate in /workspaces/*/pintos/activate; do [ -f "$activate" ] && source "$activate" && break; done' >> /home/jungle/.bashrc
 
 # Clone the repository
 # RUN git clone https://github.com/casys-kaist/pintos-kaist /home/jungle/pintos


### PR DESCRIPTION
## Summary

- DevContainer 터미널에서 Pintos 실행 스크립트가 자동으로 PATH에 잡히도록 .bashrc 설정을 수정했습니다.
- 특정 repo 이름에 의존하지 않고 /workspaces/*/pintos/activate를 탐색하도록 변경했습니다.
- 기존 실습 원본 경로는 참고용 주석으로 보존했습니다.

## Changes

- .devcontainer/Dockerfile`n  - 잘못된 고정 경로 source /workspaces/pintos_22.04_lab_docker/pintos/activate를 주석 처리
  - /workspaces/*/pintos/activate 중 존재하는 첫 번째 파일을 source하도록 변경

## Test

- Not run