### PR TITLE
feat: priority 스케줄링과 세마포어 대기열 우선순위 처리

### DIFF
--- a/docs/week9-collaboration.md
+++ b/docs/week9-collaboration.md
@@ -93,10 +93,15 @@ Project URL: https://github.com/orgs/Jungle-12-303/projects/4
 ## 8. 커밋 메시지와 PR 작성 규칙
 
 - 커밋은 한 가지 의도만 담고, 기능명이나 테스트명을 포함해 작성한다.
-- 커밋 메시지는 "무엇을 왜 바꿨는지"가 보이게 작성한다.
-- `fix`, `update`처럼 의미가 약한 단어만 단독으로 쓰지 않는다.
-- 커밋 예시: `alarm: fix simultaneous wakeup ordering`
-- 커밋 예시: `priority: yield after lowering current thread priority`
+- 커밋 메시지는 `<type>: <한국어 제목>` 형식을 따른다.
+- 커밋 제목에는 스코프를 사용하지 않는다. 영향 범위는 제목과 PR 본문에서 설명한다.
+- 허용 type은 `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `style`, `perf`, `build`, `ci`, `revert`이다.
+- 제목은 한국어 한 줄로 작성하고 마침표로 끝내지 않는다.
+- 제목은 행위가 아니라 변경 결과를 구체적으로 설명한다.
+- `수정`, `작업`, `변경`, `업데이트`, `update`, `fix`처럼 의미가 약한 표현만 단독으로 쓰지 않는다.
+- 커밋 예시: `feat: 세마포어 대기열을 우선순위 순서로 정렬`
+- 커밋 예시: `fix: 타이머 인터럽트에서 깨울 스레드 순서를 바로잡아`
+- 커밋 예시: `docs: README에 Dev Container 실행 방법을 정리`
 - PR 본문에는 관련 테스트, 수정 파일, 핵심 함수, 구현 의도, 통과/미통과 테스트, 남은 리스크를 함께 적는다.
 - PR 설명은 결과만 적지 말고, 어떤 설계 변경이 어떤 테스트에 영향을 줬는지 연결해서 쓴다.
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -173,4 +173,6 @@ int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
 
+bool thread_priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux);
+
 #endif /* threads/thread.h */

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -66,7 +66,9 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		// list_push_back (&sema->waiters, &thread_current ()->elem); // FIFO
+		/* sema.waiters도 priority 순서로 대기열에 넣음*/
+		list_insert_ordered (&sema->waiters, &thread_current ()->elem, thread_priority_compare, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -102,18 +104,41 @@ sema_try_down (struct semaphore *sema) {
    and wakes up one thread of those waiting for SEMA, if any.
 
    This function may be called from an interrupt handler. */
+/* sema_up()으로 더 높은 priority 스레드를 깨웠다면, 현재 스레드는 yield를 고려해야 한다. */
 void
 sema_up (struct semaphore *sema) {
 	enum intr_level old_level;
+	bool is_yield_necessary = false;
+	struct thread *t = thread_current();
+	struct thread *woken_t = NULL;
 
 	ASSERT (sema != NULL);
 
-	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	old_level = intr_disable (); // 인터럽트 끄기
+
+	// waiter가 있으면 가장 높은 priority waiter를 꺼내 unblock한다.
+	if (!list_empty (&sema->waiters)) {
+		woken_t = list_entry (list_pop_front (&sema->waiters), struct thread, elem);
+		thread_unblock (woken_t);
+	}
+
 	sema->value++;
-	intr_set_level (old_level);
+
+	/* sema_up()으로 더 높은 priority 스레드를 깨웠다면, 현재 스레드는 yield를 고려한다.*/
+	if (woken_t != NULL && woken_t->priority > t->priority) {
+		is_yield_necessary = true;
+	}
+
+	intr_set_level (old_level); // 인터럽트 상태 복구
+
+	// yield 필요시
+	if (is_yield_necessary) {
+		if (intr_context()) { // interrupt 문맥에서는 intr_yield_on_return()
+			intr_yield_on_return();
+		} else {
+			thread_yield(); // 일반 스레드 문맥에서 yield
+		}
+	}
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -212,6 +212,11 @@ thread_create (const char *name, int priority,
 	/* Add to run queue. */
 	thread_unblock (t);
 
+	/* 만약 새로 만든 스레드 t가 현재 실행중인 스레드보다 우선순위가 높다면, 현재 스레드가 즉시 CPU를 양보해야 한다. *현재 실행중인 스레드를 중지(yield) */
+	if (t->priority > thread_current()->priority) {
+		thread_yield();
+	}
+
 	return tid;
 }
 
@@ -230,6 +235,16 @@ wakeup_recently (const struct list_elem *a,
     return ta->wakeup_tick < tb->wakeup_tick;
 }
 
+/* priority ready_list용 우선순위 비교 함수 */
+static bool 
+priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	ASSERT (a != NULL && b != NULL);
+
+	struct thread *ta = list_entry (a, struct thread, elem);
+    struct thread *tb = list_entry (b, struct thread, elem);
+	
+	return ta->priority > tb->priority;
+}
 
 /* Puts the current thread to sleep.  It will not be scheduled
    again until awoken by thread_unblock().
@@ -266,7 +281,8 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	// list_push_back (&ready_list, &t->elem); // FIFO
+	list_insert_ordered (&ready_list, &t->elem, priority_compare, NULL); // 현재 스레드 t와 배교해서 올바른 위치에 정렬 삽입
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -331,9 +347,10 @@ thread_yield (void) {
 	old_level = intr_disable (); // ready_list와 상태 전이를 원자적으로 처리하기 위해 인터럽트 비활성화
 
 	/* idle thread는 실행할 다른 스레드가 없을 때만 선택되는 특수 스레드 => ready_list에 들어가서 경쟁하는 스레드 X */
-	if (curr != idle_thread) // 현재 스레드가 idle thread가 아닐 때
-		list_push_back (&ready_list, &curr->elem); // ready_list의 맨 마지막에 스레드를 삽입하여, 스케줄링 후보가 되도록 함
-	
+	if (curr != idle_thread) { // 현재 스레드가 idle thread가 아닐 때
+		list_insert_ordered (&ready_list, &curr->elem, priority_compare, NULL); // ready_list에 정렬 삽입
+	} /* 여기서 priority_compare는 a 스레드의 priority가 b 스레드의 priority보다 높으면 true, 같거나 낮으면 false를 반환하는 함수*/
+
 	do_schedule (THREAD_READY); // THREAD_READY로 상태 전이
 	intr_set_level (old_level); // 비활성화 이전 원래의 인터럽트 상태 (비활성화 or 활성화)로 돌려둠
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -242,7 +242,7 @@ priority_compare (const struct list_elem *a, const struct list_elem *b, void *au
 
 	struct thread *ta = list_entry (a, struct thread, elem);
     struct thread *tb = list_entry (b, struct thread, elem);
-	
+
 	return ta->priority > tb->priority;
 }
 
@@ -355,10 +355,30 @@ thread_yield (void) {
 	intr_set_level (old_level); // 비활성화 이전 원래의 인터럽트 상태 (비활성화 or 활성화)로 돌려둠
 }
 
-/* Sets the current thread's priority to NEW_PRIORITY. */
+
+/*
+	1. 현재 스레드 priority를 new_priority로 바꾼다.
+	2. ready_list에 현재 스레드보다 더 높은 priority 스레드가 있는지 확인한다.
+	3. 있다면 thread_yield() 한다.
+*/
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	struct list_elem *first_node;
+	struct thread *t;
+
+	thread_current ()->priority = new_priority; // 현재 스레드 priority를 new_priority로 바꾼다.
+	
+	if (list_empty(&ready_list)) {
+		return;
+	}
+
+	first_node = list_front(&ready_list); // ready_list의 첫 list_elem을 가져온다.
+	t = list_entry (first_node, struct thread, elem); // 그 list_elem을 포함하는 thread를 꺼낸다.
+
+	// ready_list에 현재 스레드보다 더 높은 priority 스레드가 있는지 확인한다.
+	if ( t->priority > thread_current ()->priority) {
+		thread_yield(); // 있다면 thread_yield()
+	}
 }
 
 /* Returns the current thread's priority. */
@@ -368,6 +388,7 @@ thread_get_priority (void) {
 }
 
 /* Sets the current thread's nice value to NICE. */
+
 void
 thread_set_nice (int nice UNUSED) {
 	/* TODO: Your implementation goes here */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -235,9 +235,9 @@ wakeup_recently (const struct list_elem *a,
     return ta->wakeup_tick < tb->wakeup_tick;
 }
 
-/* priority ready_list용 우선순위 비교 함수 */
-static bool 
-priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+/* 우선순위 비교 함수 - thread.c의 ready_list 및 synch.c의 sema waiters 에서 사용 */
+bool 
+thread_priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
 	ASSERT (a != NULL && b != NULL);
 
 	struct thread *ta = list_entry (a, struct thread, elem);
@@ -282,7 +282,7 @@ thread_unblock (struct thread *t) {
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
 	// list_push_back (&ready_list, &t->elem); // FIFO
-	list_insert_ordered (&ready_list, &t->elem, priority_compare, NULL); // 현재 스레드 t와 배교해서 올바른 위치에 정렬 삽입
+	list_insert_ordered (&ready_list, &t->elem, thread_priority_compare, NULL); // 현재 스레드 t와 배교해서 올바른 위치에 정렬 삽입
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -348,8 +348,8 @@ thread_yield (void) {
 
 	/* idle thread는 실행할 다른 스레드가 없을 때만 선택되는 특수 스레드 => ready_list에 들어가서 경쟁하는 스레드 X */
 	if (curr != idle_thread) { // 현재 스레드가 idle thread가 아닐 때
-		list_insert_ordered (&ready_list, &curr->elem, priority_compare, NULL); // ready_list에 정렬 삽입
-	} /* 여기서 priority_compare는 a 스레드의 priority가 b 스레드의 priority보다 높으면 true, 같거나 낮으면 false를 반환하는 함수*/
+		list_insert_ordered (&ready_list, &curr->elem, thread_priority_compare, NULL); // ready_list에 정렬 삽입
+	} /* 여기서 thread_priority_compare는 a 스레드의 priority가 b 스레드의 priority보다 높으면 true, 같거나 낮으면 false를 반환하는 함수*/
 
 	do_schedule (THREAD_READY); // THREAD_READY로 상태 전이
 	intr_set_level (old_level); // 비활성화 이전 원래의 인터럽트 상태 (비활성화 or 활성화)로 돌려둠

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -363,7 +363,6 @@ thread_yield (void) {
 */
 void
 thread_set_priority (int new_priority) {
-	struct list_elem *first_node;
 	struct thread *t;
 
 	thread_current ()->priority = new_priority; // 현재 스레드 priority를 new_priority로 바꾼다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -371,7 +371,7 @@ thread_set_priority (int new_priority) {
 		return;
 	}
 
-	t = list_entry (first_node, struct thread, elem); // 그 list_elem을 포함하는 thread를 꺼낸다.
+	t = list_entry (list_front(&ready_list), struct thread, elem); // 그 list_elem을 포함하는 thread를 꺼낸다.
 
 	// ready_list에 현재 스레드보다 더 높은 priority 스레드가 있는지 확인한다.
 	if ( t->priority > thread_current ()->priority) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -371,7 +371,6 @@ thread_set_priority (int new_priority) {
 		return;
 	}
 
-	first_node = list_front(&ready_list); // ready_list의 첫 list_elem을 가져온다.
 	t = list_entry (first_node, struct thread, elem); // 그 list_elem을 포함하는 thread를 꺼낸다.
 
 	// ready_list에 현재 스레드보다 더 높은 priority 스레드가 있는지 확인한다.


### PR DESCRIPTION
﻿## 관련 테스트

- `priority-preempt`
- `priority-change`
- `priority-fifo`
- `priority-sema`

## 수정 파일과 핵심 함수

- `pintos/threads/thread.c`
  - `thread_priority_compare()`
  - `thread_unblock()`
  - `thread_yield()`
  - `thread_create()`
  - `thread_set_priority()`
- `pintos/threads/synch.c`
  - `sema_down()`
  - `sema_up()`
- `pintos/include/threads/thread.h`
  - priority 비교 함수 선언 추가
- `docs/week9-collaboration.md`
  - 커밋 메시지 작성 규칙 정리

## 구현 의도

- `ready_list`를 priority 내림차순으로 유지해서 scheduler가 앞 원소를 꺼낼 때 가장 높은 priority thread를 선택하도록 했습니다.
- 새 thread 생성 또는 현재 thread priority 하향 후 더 높은 priority thread가 ready 상태이면 현재 thread가 yield하도록 했습니다.
- semaphore waiters도 priority 순서로 관리하고, `sema_up()`으로 더 높은 priority thread를 깨운 경우 yield를 고려하도록 했습니다.
- `sema_up()`은 interrupt context에서도 호출될 수 있으므로 일반 문맥에서는 `thread_yield()`, interrupt 문맥에서는 `intr_yield_on_return()`을 사용하도록 분기했습니다.

## 통과한 테스트

컨테이너 환경에서 아래 테스트를 확인했습니다.

```text
pass tests/threads/priority-preempt
pass tests/threads/priority-change
pass tests/threads/priority-fifo
pass tests/threads/priority-sema
```

## 남은 작업과 리스크

- `priority-condvar`는 아직 구현 전입니다.
- `priority-donate-*` 테스트를 위한 donation 구조는 아직 구현하지 않았습니다.
- donation 구현 이후 priority 비교 기준이 effective priority로 확장될 수 있으므로 waiters 정렬 로직 재검토가 필요합니다.
