### PR TITLE
feat: 유저프로그램 공통 인터페이스 추가

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -9,6 +9,11 @@
 #include "vm/vm.h"
 #endif
 
+#ifdef USERPROG
+struct child_status;
+struct file;
+#endif
+
 void thread_wakeup(int64_t now_ticks); // sleep_list 순회 후 기다릴 시간이 지난 스레드 깨우는 함수
 
 /* States in a thread's life cycle. */
@@ -127,6 +132,11 @@ struct thread {
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
 	int exit_status;
+	struct list fd_table;              /* Per-process file descriptors. */
+	int next_fd;                       /* Next fd number for regular files. */
+	struct list children;              /* Direct child process states. */
+	struct child_status *child_info;   /* State shared with this process's parent. */
+	struct file *exec_file;            /* Executable kept open for write denial. */
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -1,13 +1,39 @@
 #ifndef USERPROG_PROCESS_H
 #define USERPROG_PROCESS_H
 
+#include <stdbool.h>
 #include "threads/thread.h"
+#include "threads/synch.h"
+
+struct file;
+
+struct child_status {
+	tid_t tid;
+	int exit_status;
+	bool waited;
+	bool load_done;
+	bool load_success;
+	int ref_cnt;
+	struct semaphore load_sema;
+	struct semaphore exit_sema;
+	struct list_elem elem;
+};
 
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);
 int process_wait (tid_t);
 void process_exit (void);
+void process_user_init (struct thread *t);
+void process_exit_with_status (int status) NO_RETURN;
 void process_activate (struct thread *next);
+
+int process_add_file (struct file *file);
+struct file *process_get_file (int fd);
+bool process_close_file (int fd);
+void process_close_all_files (void);
+bool process_duplicate_fds (struct thread *dst, struct thread *src);
+struct child_status *process_find_child (tid_t tid);
+void child_status_release (struct child_status *cs);
 
 #endif /* userprog/process.h */

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -1,6 +1,16 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
+#include <stddef.h>
+#include "threads/synch.h"
+
+extern struct lock filesys_lock;
+
 void syscall_init (void);
+void user_check_ptr (const void *uaddr);
+void user_check_read (const void *uaddr, size_t size);
+void user_check_write (void *uaddr, size_t size);
+void user_check_string (const char *uaddr);
+char *user_strdup (const char *uaddr);
 
 #endif /* userprog/syscall.h */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -13,6 +13,7 @@
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "threads/interrupt.h"
+#include "threads/malloc.h"
 #include "threads/palloc.h"
 #include "threads/thread.h"
 #include "threads/mmu.h"
@@ -28,10 +29,178 @@ static bool load (char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
+struct fd_entry {
+	int fd;
+	struct file *file;
+	struct list_elem elem;
+};
+
+static bool process_list_initialized (struct list *list);
+static struct fd_entry *process_find_fd_entry (struct thread *t, int fd);
+static void process_close_files (struct thread *t);
+
 /* General process initializer for initd and other process. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
+	process_user_init (current);
+}
+
+void
+process_user_init (struct thread *t) {
+	ASSERT (t != NULL);
+
+	if (!process_list_initialized (&t->fd_table))
+		list_init (&t->fd_table);
+	if (!process_list_initialized (&t->children))
+		list_init (&t->children);
+	if (t->next_fd < 2)
+		t->next_fd = 2;
+}
+
+static bool
+process_list_initialized (struct list *list) {
+	return list->head.next != NULL && list->tail.prev != NULL;
+}
+
+int
+process_add_file (struct file *file) {
+	struct thread *cur = thread_current ();
+	struct fd_entry *entry;
+
+	if (file == NULL)
+		return -1;
+
+	process_user_init (cur);
+	entry = malloc (sizeof *entry);
+	if (entry == NULL)
+		return -1;
+
+	entry->fd = cur->next_fd++;
+	entry->file = file;
+	list_push_back (&cur->fd_table, &entry->elem);
+	return entry->fd;
+}
+
+static struct fd_entry *
+process_find_fd_entry (struct thread *t, int fd) {
+	struct list_elem *e;
+
+	if (t == NULL || !process_list_initialized (&t->fd_table))
+		return NULL;
+
+	for (e = list_begin (&t->fd_table); e != list_end (&t->fd_table);
+			e = list_next (e)) {
+		struct fd_entry *entry = list_entry (e, struct fd_entry, elem);
+		if (entry->fd == fd)
+			return entry;
+	}
+	return NULL;
+}
+
+struct file *
+process_get_file (int fd) {
+	struct fd_entry *entry = process_find_fd_entry (thread_current (), fd);
+	return entry != NULL ? entry->file : NULL;
+}
+
+bool
+process_close_file (int fd) {
+	struct fd_entry *entry = process_find_fd_entry (thread_current (), fd);
+
+	if (entry == NULL)
+		return false;
+
+	list_remove (&entry->elem);
+	file_close (entry->file);
+	free (entry);
+	return true;
+}
+
+void
+process_close_all_files (void) {
+	process_close_files (thread_current ());
+}
+
+static void
+process_close_files (struct thread *t) {
+	if (t == NULL || !process_list_initialized (&t->fd_table))
+		return;
+
+	while (!list_empty (&t->fd_table)) {
+		struct list_elem *e = list_pop_front (&t->fd_table);
+		struct fd_entry *entry = list_entry (e, struct fd_entry, elem);
+		file_close (entry->file);
+		free (entry);
+	}
+}
+
+bool
+process_duplicate_fds (struct thread *dst, struct thread *src) {
+	struct list_elem *e;
+
+	ASSERT (dst != NULL);
+	ASSERT (src != NULL);
+
+	process_user_init (dst);
+	if (!process_list_initialized (&src->fd_table))
+		return true;
+
+	dst->next_fd = src->next_fd;
+	for (e = list_begin (&src->fd_table); e != list_end (&src->fd_table);
+			e = list_next (e)) {
+		struct fd_entry *src_entry = list_entry (e, struct fd_entry, elem);
+		struct fd_entry *dst_entry = malloc (sizeof *dst_entry);
+		if (dst_entry == NULL)
+			goto fail;
+
+		dst_entry->fd = src_entry->fd;
+		dst_entry->file = file_duplicate (src_entry->file);
+		if (dst_entry->file == NULL) {
+			free (dst_entry);
+			goto fail;
+		}
+		list_push_back (&dst->fd_table, &dst_entry->elem);
+	}
+	return true;
+
+fail:
+	process_close_files (dst);
+	return false;
+}
+
+struct child_status *
+process_find_child (tid_t tid) {
+	struct thread *cur = thread_current ();
+	struct list_elem *e;
+
+	if (!process_list_initialized (&cur->children))
+		return NULL;
+
+	for (e = list_begin (&cur->children); e != list_end (&cur->children);
+			e = list_next (e)) {
+		struct child_status *cs = list_entry (e, struct child_status, elem);
+		if (cs->tid == tid)
+			return cs;
+	}
+	return NULL;
+}
+
+void
+child_status_release (struct child_status *cs) {
+	if (cs == NULL)
+		return;
+
+	cs->ref_cnt--;
+	if (cs->ref_cnt <= 0)
+		free (cs);
+}
+
+void
+process_exit_with_status (int status) {
+	thread_current ()->exit_status = status;
+	thread_exit ();
+	NOT_REACHED ();
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
@@ -245,6 +414,12 @@ void
 process_exit (void) {
 	struct thread *curr = thread_current ();
 	printf ("%s: exit(%d)\n", curr->name, curr->exit_status); 
+	process_close_all_files ();
+	if (curr->exec_file != NULL) {
+		file_allow_write (curr->exec_file);
+		file_close (curr->exec_file);
+		curr->exec_file = NULL;
+	}
 	process_cleanup ();
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,15 +1,23 @@
 #include "userprog/syscall.h"
 #include <stdio.h>
 #include <syscall-nr.h>
+#include <string.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
+#include "threads/mmu.h"
+#include "threads/palloc.h"
+#include "threads/vaddr.h"
 #include "userprog/gdt.h"
+#include "userprog/process.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
+static bool user_addr_mapped (const void *uaddr);
+
+struct lock filesys_lock;
 
 /* System call.
  *
@@ -26,6 +34,8 @@ void syscall_handler (struct intr_frame *);
 
 void
 syscall_init (void) {
+	lock_init (&filesys_lock);
+
 	write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48  |
 			((uint64_t)SEL_KCSEG) << 32);
 	write_msr(MSR_LSTAR, (uint64_t) syscall_entry);
@@ -35,6 +45,80 @@ syscall_init (void) {
 	 * mode stack. Therefore, we masked the FLAG_FL. */
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+}
+
+static bool
+user_addr_mapped (const void *uaddr) {
+	struct thread *cur = thread_current ();
+
+	return uaddr != NULL
+		&& is_user_vaddr (uaddr)
+		&& cur->pml4 != NULL
+		&& pml4_get_page (cur->pml4, uaddr) != NULL;
+}
+
+void
+user_check_ptr (const void *uaddr) {
+	if (!user_addr_mapped (uaddr))
+		process_exit_with_status (-1);
+}
+
+void
+user_check_read (const void *uaddr, size_t size) {
+	uint64_t start;
+	uint64_t last;
+	uint64_t page;
+
+	if (size == 0)
+		return;
+	if (uaddr == NULL)
+		process_exit_with_status (-1);
+
+	start = (uint64_t) uaddr;
+	last = start + size - 1;
+	if (last < start)
+		process_exit_with_status (-1);
+
+	for (page = (uint64_t) pg_round_down ((void *) start);
+			page <= (uint64_t) pg_round_down ((void *) last);
+			page += PGSIZE)
+		user_check_ptr ((const void *) page);
+}
+
+void
+user_check_write (void *uaddr, size_t size) {
+	user_check_read (uaddr, size);
+}
+
+void
+user_check_string (const char *uaddr) {
+	const char *p;
+
+	for (p = uaddr; ; p++) {
+		user_check_ptr (p);
+		if (*p == '\0')
+			return;
+	}
+}
+
+char *
+user_strdup (const char *uaddr) {
+	char *copy;
+	size_t i;
+
+	copy = palloc_get_page (0);
+	if (copy == NULL)
+		process_exit_with_status (-1);
+
+	for (i = 0; i < PGSIZE; i++) {
+		user_check_ptr (uaddr + i);
+		copy[i] = uaddr[i];
+		if (copy[i] == '\0')
+			return copy;
+	}
+
+	palloc_free_page (copy);
+	process_exit_with_status (-1);
 }
 
 void


### PR DESCRIPTION
## 무엇을 변경했나요?

프로젝트2 user programs 병렬 구현을 위해 공통 인터페이스를 추가했습니다.

## 왜 변경했나요?

FD 테이블, child process 상태, user pointer 검증, 파일 시스템 lock 경계를 먼저 맞춰두면 팀원 A/B/C가 충돌을 줄이고 병렬로 구현할 수 있습니다.

## 어떻게 구현했나요?

- `struct thread`에 userprog용 FD 테이블, child 목록, 실행 파일 추적 필드를 추가했습니다.
- `process.h/process.c`에 FD 관리, child 상태, exit status 처리용 helper를 추가했습니다.
- `syscall.h/syscall.c`에 전역 `filesys_lock`과 user pointer/string 검증 helper를 추가했습니다.

## 테스트

- [x] `git diff --cached --check`
- [x] `pintos/userprog make -j4`

## 체크리스트

- [x] 프로젝트 스타일 가이드 준수
- [x] 자기 리뷰 완료
- [x] 새로운 경고 없음
- [x] 로컬에서 빌드 통과