### PR TITLE
feat: 시스템 콜 디스패처 기본 뼈대 추가

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -240,6 +240,8 @@ process_create_initd (const char *file_name) {
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (thread_name, PRI_DEFAULT, initd, fn_copy);
+	palloc_free_page (thread_name); // thread_name 메모리 해제
+
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
 	return tid;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 #include <string.h>
+#include "threads/init.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
@@ -127,164 +128,64 @@ syscall_handler (struct intr_frame *f) {
 
 	switch (f->R.rax)
 	{
-	case SYS_WRITE:
-		putbuf((char *)f->R.rsi, f->R.rdx);
-		f->R.rax = f->R.rdx;
+	/* Projects 2 and later. */
+	case SYS_HALT:                   /* Halt the operating system. */
+		power_off(); // OS 종료
 		break;
-		// TODO: 시스템 콜 번호에 따른 추가 구현 필요
-	case SYS_EXIT:
-		thread_current()->exit_status = f->R.rdi;
-		thread_exit ();
+	case SYS_EXIT:                   /* Terminate this process. */
+		process_exit_with_status((int) f->R.rdi);
+		break;
+	case SYS_FORK:// TODO: B                   /* Clone current process. */
+		f->R.rax = -1;
+		break;
+	case SYS_EXEC:// TODO: B                   /* Switch current process. */
+		f->R.rax = -1;
+		break;
+	case SYS_WAIT:// TODO: B                   /* Wait for a child process to die. */
+		f->R.rax = -1;
+		break;
+	case SYS_CREATE:// TODO: A                 /* Create a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_REMOVE:// TODO: A                 /* Delete a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_OPEN:// TODO: A                   /* Open a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_FILESIZE:// TODO: A               /* Obtain a file's size. */
+		f->R.rax = -1;
+		break;
+	case SYS_READ:// TODO: A                   /* Read from a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_WRITE: { // TODO: A               /* Write to a file. */
+		int fd = (int) f->R.rdi;
+		const char *buffer = (const char *) f->R.rsi;  /* user buffer address */
+		unsigned size = (unsigned) f->R.rdx;
+
+		// 사용자 버퍼 검증 함수 작성 필요
+
+		if (fd == 1) {
+			putbuf (buffer, size);
+			f->R.rax = size;
+		} else {
+			f->R.rax = -1;
+		}
+
+		break;
+	}
+	case SYS_SEEK:// TODO: A                   /* Change position in a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_TELL:// TODO: A                   /* Report current position in a file. */
+		f->R.rax = -1;
+		break;
+	case SYS_CLOSE:// TODO: A                  /* Close a file. */
+		f->R.rax = -1;
 		break;
 	default:
-		thread_exit ();
+		process_exit_with_status (-1); // 프로세스를 비정상 종료
 		break;
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// /* The main system call interface */
-// void
-// syscall_handler (struct intr_frame *f) {
-
-// 	switch (f->R.rax) {
-// 		case SYS_WRITE: {
-// 			/* SYS_WRITE arguments: fd, buffer, size. */
-// 			/* 반환값은 f->R.rax에 저장 */
-// 			int fd = (int) f->R.rdi;  /* fd */
-// 			const char *buffer = (const char *) f->R.rsi;  /* user buffer address */
-// 			unsigned size = (unsigned) f->R.rdx;
-
-// 			validate_user_buffer (buffer, size); // 버퍼 검증 함수
-
-// 			if (fd == 1) {
-// 				putbuf (buffer, size);
-// 				f->R.rax = size;
-// 			} else {
-// 				f->R.rax = -1;
-// 			}
-// 			break;
-// 		}
-
-// 		case SYS_EXIT:
-// 			/* f->R.rdi가 exit status */
-// 			exit_process ((int) f->R.rdi);
-// 			break;
-
-// 		case SYS_HALT:
-// 			power_off(); // OS 종료
-// 			break;
-
-// 		default:
-// 			/* 잘못된 syscall이면 프로세스 종료 */
-// 			exit_process(-1);
-// 			break;
-// 	}
-// }
-
-// /* syscall arguments are passed in f->R.* registers.
-//    Store the syscall return value in f->R.rax. */
-
-// /* 입력값 검증 헬퍼 함수 */
-// static void
-// validate_user_ptr (const void *uaddr) {
-// 	// 만약 이 user address가 현재 프로세스 주소 공간에서 유효하지 않을 경우 exit
-// 	if (uaddr == NULL || !is_user_vaddr (uaddr) ||
-// 	    pml4_get_page (thread_current ()->pml4, uaddr) == NULL) {
-// 		exit_process (-1);
-// 	}
-// }
-
-// static void
-// validate_user_buffer (const void *buffer, size_t size) {
-
-// 	// size == 0이면 접근할 메모리가 없으므로 바로 성공 처리
-// 	if (size == 0) {
-// 		return;
-// 	}
-
-// 	if (buffer == NULL) {
-// 		exit_process (-1);
-// 	}
-
-// 	// 시작, 끝 주소를 정수로 계산하고 overflow를 확인
-// 	uintptr_t start_addr = (uintptr_t) buffer;
-// 	uintptr_t last_addr = start_addr + size - 1;
-
-// 	if (last_addr < start_addr) {
-// 		exit_process (-1);
-// 	}
-
-// 	// 바이트 단위 포인터 산술을 위해 uint8_t 포인터로 변환한다.
-// 	const uint8_t *start = (const uint8_t *) start_addr;
-// 	const uint8_t *last = (const uint8_t *) last_addr;
-// 	const uint8_t *page_start = (const uint8_t *) pg_round_down (start);
-// 	const uint8_t *page_end = (const uint8_t *) pg_round_down (last);
-
-// 	// buffer가 걸친 모든 페이지가 매핑되어 있는지 확인
-// 	for (const uint8_t *page = page_start; page <= page_end; page += PGSIZE) {
-// 		validate_user_ptr (page);
-// 	}
-
-// 	// 실제 접근 시작, 끝 주소가 user 영역 안에 있는지 확인한다.
-// 	validate_user_ptr (start);
-// 	validate_user_ptr (last);
-// }
-
-// static void
-// validate_user_string (const char *str) {
-// 	/* TODO: 검증 로직 구현 필요 */
-// 	/* 구현 후 open/create/exec에서 사용하면 됨 */
-// }
-
-// static void
-// exit_process (int status) {
-// 	printf ("%s: exit(%d)\n", thread_name (), status);
-// 	/* TODO: thread 에 exit_status 저장 로직 구현 필요 */
-// 	// 현재는 임시 구현이며, 향후 thread->exit_status 추가하고 0, -1 같은 프로세스 종료 코드를 넣는 등의 조치 필요
-// 	thread_exit ();
-// }


### PR DESCRIPTION
## 무엇을 변경했나요?

- `syscall_handler()`에 Project 2 syscall 번호별 기본 분기 추가
- 미구현 syscall은 임시로 `-1` 반환
- `SYS_HALT`, `SYS_EXIT`, stdout `SYS_WRITE` 기본 처리 정리
- 오래된 주석 처리 예시 코드 제거

## 테스트

- [x] `cd pintos/userprog && make`
