### PR TITLE
feat: fork 기본 실행 흐름 추가

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -269,33 +269,21 @@ initd (void *f_name) {
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
-
- /*
-	아래의 내용을 반영해야 함.
-
-	1. process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 준비
-	2. child_status 생성 및 children list 연결
-	3. thread_create()에 parent thread만 넘기는 대신 aux 구조체 넘기기
-	4. parent는 child가 복제 성공/실패를 알릴 때까지 기다리기
-	5. __do_fork()에서 aux를 받아 intr_frame 복사
-	6. child 쪽 if_.R.rax = 0 설정
- */
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
-	/* Clone current thread to new thread.*/
-	tid_t tid;
-	struct fork_aux *aux = malloc (sizeof *aux); // aux 구조체 할당
-
+	/* process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 할당.*/
+	struct fork_aux *aux = malloc (sizeof *aux);
 	if (aux == NULL) {
 		return TID_ERROR;
 	}
 
 	aux->parent = thread_current (); // parent 저장
 
+	/* 부모의 syscall 진입 시점 레지스터 상태를 자식에게 넘기기 위해 aux에 복사한다. */
 	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
 
-	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux); // thread_create에 aux 전달
-
+	/* thread_create에 parent thread 대신 aux 전달. __do_fork()에서는 aux를 받아 intr_frame 복사 */
+	tid_t tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
 	if (tid == TID_ERROR) {
 		free(aux);
 		return TID_ERROR;
@@ -316,22 +304,36 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	bool writable;
 
 	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
+	if (is_kern_pte (pte)) {
+		return true;
+	}
 
 	/* 2. Resolve VA from the parent's page map level 4. */
 	parent_page = pml4_get_page (parent->pml4, va);
+	if (parent_page == NULL) {
+		return false;
+	}
 
-	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
-	 *    TODO: NEWPAGE. */
+	/* 3. Allocate new PAL_USER page for the child and set result to NEWPAGE. */
+	newpage = palloc_get_page (PAL_USER);
+	if (newpage == NULL) {
+		return false;
+	}
 
-	/* 4. TODO: Duplicate parent's page to the new page and
-	 *    TODO: check whether parent's page is writable or not (set WRITABLE
-	 *    TODO: according to the result). */
+	/* 4. Duplicate parent's page to the new page and
+	 *    check whether parent's page is writable or not (set WRITABLE
+	 *    according to the result). */
+	memcpy (newpage, parent_page, PGSIZE);
 
 	/* 5. Add new page to child's page table at address VA with WRITABLE
 	 *    permission. */
+	writable = is_writable (pte);
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: if fail to insert page, do error handling. */
+		/* 6. if fail to insert page, do error handling. */
+		palloc_free_page (newpage);
+		return false;
 	}
+
 	return true;
 }
 #endif
@@ -342,7 +344,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       this function. */
 
 /* __do_fork()가 thread_current()만 받은 것이 아니라,
-	process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
+   process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
 */
 static void
 __do_fork (void *aux) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -29,6 +29,12 @@ static bool load (char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
+// thread fork를 위한 구조체
+struct fork_aux {
+	struct thread *parent;
+	struct intr_frame parent_if;
+};
+
 struct fd_entry {
 	int fd;
 	struct file *file;
@@ -263,11 +269,39 @@ initd (void *f_name) {
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
+
+ /*
+	아래의 내용을 반영해야 함.
+
+	1. process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 준비
+	2. child_status 생성 및 children list 연결
+	3. thread_create()에 parent thread만 넘기는 대신 aux 구조체 넘기기
+	4. parent는 child가 복제 성공/실패를 알릴 때까지 기다리기
+	5. __do_fork()에서 aux를 받아 intr_frame 복사
+	6. child 쪽 if_.R.rax = 0 설정
+ */
 tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
+process_fork (const char *name, struct intr_frame *if_) {
 	/* Clone current thread to new thread.*/
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+	tid_t tid;
+	struct fork_aux *aux = malloc (sizeof *aux); // aux 구조체 할당
+
+	if (aux == NULL) {
+		return TID_ERROR;
+	}
+
+	aux->parent = thread_current (); // parent 저장
+
+	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
+
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux); // thread_create에 aux 전달
+
+	if (tid == TID_ERROR) {
+		free(aux);
+		return TID_ERROR;
+	}
+
+	return tid;
 }
 
 #ifndef VM
@@ -306,17 +340,28 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  * Hint) parent->tf does not hold the userland context of the process.
  *       That is, you are required to pass second argument of process_fork to
  *       this function. */
+
+/* __do_fork()가 thread_current()만 받은 것이 아니라,
+	process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
+*/
 static void
 __do_fork (void *aux) {
-	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
+	struct fork_aux *fork_aux = aux; // void *aux를 struct fork_aux *로 해석하기 위해 형변환
+	struct intr_frame if_; // 인터럽트/시스템콜 진입 시점의 CPU 레지스터 상태를 담는 구조체 변수
+	struct thread *parent = fork_aux->parent;
 	struct thread *current = thread_current ();
-	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-	struct intr_frame *parent_if;
+	struct intr_frame *parent_if = &fork_aux->parent_if;
 	bool succ = true;
 
 	/* 1. Read the cpu context to local stack. */
+	/* fork()에서는 부모와 자식이 거의 같은 실행 상태에서 이어서 실행되어야 함.
+		그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+	if_.R.rax = 0; // 자식은 fork()의 반환값이 0이어야 함
+
+	// 사용한 메모리 해제
+	free (fork_aux);
+	fork_aux = NULL;
 
 	/* 2. Duplicate PT */
 	current->pml4 = pml4_create();
@@ -332,12 +377,6 @@ __do_fork (void *aux) {
 	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
 		goto error;
 #endif
-
-	/* TODO: Your code goes here.
-	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
-	 * TODO:       in include/filesys/file.h. Note that parent should not return
-	 * TODO:       from the fork() until this function successfully duplicates
-	 * TODO:       the resources of parent.*/
 
 	process_init ();
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -33,6 +33,7 @@ static void __do_fork (void *);
 struct fork_aux {
 	struct thread *parent;
 	struct intr_frame parent_if;
+	struct child_status *child_info;
 };
 
 struct fd_entry {
@@ -271,13 +272,38 @@ initd (void *f_name) {
  * TID_ERROR if the thread cannot be created. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
+
+	struct thread *parent = thread_current (); // 현재 스레드가 부모 스레드가 됨
+
 	/* process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 할당.*/
 	struct fork_aux *aux = malloc (sizeof *aux);
 	if (aux == NULL) {
 		return TID_ERROR;
 	}
 
-	aux->parent = thread_current (); // parent 저장
+	// 자식 상태 구조체 할당
+	struct child_status *cs = malloc (sizeof *cs);
+	if (cs == NULL) {
+		free (aux);
+		return TID_ERROR;
+	}
+
+	/* cs 초기화 */
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	cs->load_done = false;
+	cs->load_success = false;
+	cs->ref_cnt = 2;
+	sema_init (&cs->load_sema, 0);
+	sema_init (&cs->exit_sema, 0);
+
+	// 현재 실행 중인 부모 thread의 children 리스트에 새 자식 상태 cs를 등록
+	list_push_back (&parent->children, &cs->elem);
+
+	aux->child_info = cs; // child 저장
+
+	aux->parent = parent; // parent 저장
 
 	/* 부모의 syscall 진입 시점 레지스터 상태를 자식에게 넘기기 위해 aux에 복사한다. */
 	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
@@ -285,7 +311,19 @@ process_fork (const char *name, struct intr_frame *if_) {
 	/* thread_create에 parent thread 대신 aux 전달. __do_fork()에서는 aux를 받아 intr_frame 복사 */
 	tid_t tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
 	if (tid == TID_ERROR) {
+		list_remove (&cs->elem);
+		free (cs);
 		free(aux);
+		return TID_ERROR;
+	}
+
+	// 부모, 자식의 tid 동기화
+	cs->tid = tid;
+	sema_down (&cs->load_sema);
+	if (!cs->load_success) {
+		list_remove (&cs->elem);
+		child_status_release (cs);
+		child_status_release (cs);
 		return TID_ERROR;
 	}
 
@@ -355,6 +393,8 @@ __do_fork (void *aux) {
 	struct intr_frame *parent_if = &fork_aux->parent_if;
 	bool succ = true;
 
+	current->child_info = fork_aux->child_info;
+
 	/* 1. Read the cpu context to local stack. */
 	/* fork()에서는 부모와 자식이 거의 같은 실행 상태에서 이어서 실행되어야 함.
 		그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
@@ -366,27 +406,49 @@ __do_fork (void *aux) {
 	fork_aux = NULL;
 
 	/* 2. Duplicate PT */
+	/* 주소 공간 복제 */
 	current->pml4 = pml4_create();
-	if (current->pml4 == NULL)
-		goto error;
+	if (current->pml4 == NULL) {
+		succ = false;
+		goto done;
+	}
+
 
 	process_activate (current);
 #ifdef VM
 	supplemental_page_table_init (&current->spt);
-	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
-		goto error;
+	if (!supplemental_page_table_copy (&current->spt, &parent->spt)) {
+		succ = false;
+		goto done;
+	}
 #else
-	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
-		goto error;
+	if (!pml4_for_each (parent->pml4, duplicate_pte, parent)) {
+		succ = false;
+		goto done;
+	}
 #endif
 
+	/* 자식 userprog 상태 초기화 */
 	process_init ();
 
+	/* 부모 fd table 복제 */
+	if (!process_duplicate_fds (current, parent)) {
+		succ = false;
+		goto done;
+	}
+
+	/* 성공/실패 결과를 child_status에 기록. 부모에게 fork 준비 완료를 알림 */
+done:
+	current->child_info->load_success = succ;
+	current->child_info->load_done = true;
+	sema_up (&current->child_info->load_sema); // sema_up()으로 부모 깨움
+
 	/* Finally, switch to the newly created process. */
-	if (succ)
-		do_iret (&if_);
-error:
-	thread_exit ();
+	if (succ) {
+		do_iret (&if_); // 성공이면 do_iret()
+	}
+
+	thread_exit (); // 실패면 thread_exit()
 }
 
 /* Switch the current execution context to the f_name.
@@ -463,6 +525,13 @@ process_exit (void) {
 		file_close (curr->exec_file);
 		curr->exec_file = NULL;
 	}
+
+	// 부모가 wait()에서 받을 수 있도록 현재 프로세스의 종료 상태를 기록
+	if (curr->child_info != NULL) {
+		curr->child_info->exit_status = curr->exit_status;
+		sema_up (&curr->child_info->exit_sema);
+	}
+
 	process_cleanup ();
 }
 
@@ -683,15 +752,16 @@ load (char *file_name, struct intr_frame *if_) {
 	}
 
 	/* Set up stack. */
-	if (!setup_stack (if_))
+	if (!setup_stack (if_)) {
 		goto done;
+	}
 
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
 	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_argv 끝부터 역순으로 넣는다.)
 	if_->rsp = USER_STACK;
-	
+
 	// 문자열들을 복사하여 실제 argv 배열에 역순으로 넣기
 	for (int i = argc - 1; i >= 0; i--) {
 		size_t len = strlen (tmp_argv[i]) + 1;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -577,26 +577,25 @@ load (char *file_name, struct intr_frame *if_) {
 	off_t file_ofs;
 	bool success = false;
 	int i;
-	int order_size = strlen(file_name);
 	size_t padding; // word-align
 	
 	/* Allocate and activate page directory. */
 	/* 해당 프로세스의 사용자 가상 주소 공간 */
 	t->pml4 = pml4_create ();
-	if (t->pml4 == NULL)
-	goto done;
+	if (t->pml4 == NULL) {
+		goto done;
+	}
+
 	process_activate (thread_current ());
 
-	// file_name 을 파싱하는 함수가 이 단계 이전 어딘가에 들어가야 함.
 	// 토크나이저 사용
 	int64_t argc = 0;		// argv 개수
 	char *tmp_argv[MAX_ARGV]; // 임시 argv 배열
 	char *argv[MAX_ARGV + 1];	// argv 배열
-	char * save_ptr = NULL; // file_name의 마지막 주소 보관
+	char *save_ptr = NULL; // file_name의 마지막 주소 보관
 	char *token;
 
-	for (token = strtok_r(file_name, " ", &save_ptr); token != NULL; token = strtok_r(NULL, " ", &save_ptr)) {
-		
+	for (token = strtok_r (file_name, " ", &save_ptr); token != NULL; token = strtok_r (NULL, " ", &save_ptr)) {
 		// 메모리 오염 방어 코드
 		if (argc >= MAX_ARGV) { 
 			goto done;
@@ -607,7 +606,6 @@ load (char *file_name, struct intr_frame *if_) {
 	}
 
 	// filesys_open(tmp_argv[0])에서 초기화되지 않은 값을 쓰는 상황을 막기 위한 방어 코드
-	
 	if (argc == 0) {
 		goto done;
 	}
@@ -691,18 +689,15 @@ load (char *file_name, struct intr_frame *if_) {
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-
-	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_arvg 끝부터 역순으로 넣는다.) 
+	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_argv 끝부터 역순으로 넣는다.)
 	if_->rsp = USER_STACK;
 	
 	// 문자열들을 복사하여 실제 argv 배열에 역순으로 넣기
-	for (int i = argc - 1; i >= 0 ; i--) {
+	for (int i = argc - 1; i >= 0; i--) {
 		size_t len = strlen (tmp_argv[i]) + 1;
 
 		if_->rsp -= len; // 넣을 만큼 빼주어야 함
-		memcpy((void *)if_->rsp, tmp_argv[i], len); // start / end / sizeof
+		memcpy ((void *)if_->rsp, tmp_argv[i], len); // start / end / sizeof
 
 		// argv[] 에 스택의 주소값 저장
 		argv[i] = (char *)if_->rsp;	
@@ -723,7 +718,7 @@ load (char *file_name, struct intr_frame *if_) {
 		if_->rsp -= sizeof(argv[i]);
 
 		// 스택에 argv[]의 인자의 주소값 저장
-		memcpy((void *)if_->rsp, &argv[i], sizeof(argv[i]));
+		memcpy ((void *)if_->rsp, &argv[i], sizeof(argv[i]));
 		// printf("&argv[i] === %x\n", argv[i]); // debug
 	}
 
@@ -734,7 +729,7 @@ load (char *file_name, struct intr_frame *if_) {
 	// fake address 반환 - 문자열 "0"이 아닌 8바이트짜리 NULL 값을 넣어야 함.
 	void *fake_ret = NULL;
 	if_->rsp -= sizeof(fake_ret);
-	memcpy((void *)if_->rsp, &fake_ret, sizeof(fake_ret));
+	memcpy ((void *)if_->rsp, &fake_ret, sizeof(fake_ret));
 
 	success = true;
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -148,9 +148,14 @@ syscall_handler (struct intr_frame *f) {
 	case SYS_EXIT:                   /* Terminate this process. */
 		process_exit_with_status((int) f->R.rdi);
 		break;
-	case SYS_FORK:// TODO: B                   /* Clone current process. */
-		f->R.rax = -1;
-		break;	
+	//
+	case SYS_FORK: {                   /* Clone current process. */
+		const char *thread_name = (const char *) f->R.rdi; // fork(const char *thread_name)의 첫 번째 인자
+
+		user_check_string (thread_name);
+		f->R.rax = process_fork (thread_name, f); // fork() syscall 실패시 부모에게 -1 반환, 성공시 child tid 반환
+		break;
+	}
 	// 이미 실행 중인 user process가 exec()를 요청한 상황
 	case SYS_EXEC: {                   /* Switch current process. */
 		const char *cmd_line = (const char *) f->R.rdi; // exec(const char *file)의 첫 번째 인자


### PR DESCRIPTION
## 무엇을 변경했나요?

- fork syscall에서 부모 실행 문맥을 자식에게 전달하는 구조 추가
- 부모 주소 공간을 자식 pml4로 복제하는 duplicate_pte() 구현
- child_status를 process_fork()와 __do_fork()에 연결
- 자식 주소 공간 및 fd 복제 완료 여부를 부모가 기다리도록 동기화
- load() 인자 처리 주변 미사용 변수와 주석/스타일 정리

## 왜 변경했나요?

fork 이후 자식이 부모의 실행 상태, 주소 공간, fd table을 이어받고 부모가 자식 복제 완료 전 먼저 진행하지 않도록 하기 위함입니다.

## 테스트

- [x] make -C pintos/userprog/build
- [ ] tests/userprog/fork-once.result

참고: fork-once는 자식이 exit(81)까지 실행되지만, process_wait()의 종료 상태 수집이 아직 후속 구현 예정이라 현재는 wait 결과가 -1로 남습니다.