### PR TITLE
feat: wait 시스템 콜과 initd 종료 동기화 추가

### DIFF
--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -8,15 +8,15 @@
 struct file;
 
 struct child_status {
-	tid_t tid;
-	int exit_status;
-	bool waited;
-	bool load_done;
-	bool load_success;
-	int ref_cnt;
-	struct semaphore load_sema;
-	struct semaphore exit_sema;
-	struct list_elem elem;
+	tid_t tid;                  // 자식 thread의 id
+	int exit_status;            // 자식의 종료 상태 - 자식이 exit(status) 하거나 예외로 죽으면 이 값이 기록되고 부모의 wait()가 이 값을 반환
+	bool waited;                // 부모가 이미 이 자식에 대해 wait()를 호출했는지 표시
+	bool load_done;             // 자식의 load 또는 fork 준비가 끝났는지 나타내는 상태값
+	bool load_success;          // 자식이 실행 준비에 성공했는지 표시 - 실패하면 부모의 fork 반환값은 TID_ERROR 또는 -1
+	int ref_cnt;                // child_status를 몇 쪽에서 아직 사용 중인지 세는 값. 처음에는 부모와 자식이 참조하므로 2
+	struct semaphore load_sema; // 부모가 자식의 "생성/로드 준비 완료"를 기다릴 때 쓰는 세마포어
+	struct semaphore exit_sema; // 부모가 자식 종료를 기다릴 때 쓰는 세마포어
+	struct list_elem elem;      // 부모의 children 리스트에 child_status를 넣기 위한 리스트 연결 필드
 };
 
 tid_t process_create_initd (const char *file_name);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -269,33 +269,21 @@ initd (void *f_name) {
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
-
- /*
-	아래의 내용을 반영해야 함.
-
-	1. process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 준비
-	2. child_status 생성 및 children list 연결
-	3. thread_create()에 parent thread만 넘기는 대신 aux 구조체 넘기기
-	4. parent는 child가 복제 성공/실패를 알릴 때까지 기다리기
-	5. __do_fork()에서 aux를 받아 intr_frame 복사
-	6. child 쪽 if_.R.rax = 0 설정
- */
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
-	/* Clone current thread to new thread.*/
-	tid_t tid;
-	struct fork_aux *aux = malloc (sizeof *aux); // aux 구조체 할당
-
+	/* process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 할당.*/
+	struct fork_aux *aux = malloc (sizeof *aux);
 	if (aux == NULL) {
 		return TID_ERROR;
 	}
 
 	aux->parent = thread_current (); // parent 저장
 
+	/* 부모의 syscall 진입 시점 레지스터 상태를 자식에게 넘기기 위해 aux에 복사한다. */
 	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
 
-	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux); // thread_create에 aux 전달
-
+	/* thread_create에 parent thread 대신 aux 전달. __do_fork()에서는 aux를 받아 intr_frame 복사 */
+	tid_t tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
 	if (tid == TID_ERROR) {
 		free(aux);
 		return TID_ERROR;
@@ -316,22 +304,36 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	bool writable;
 
 	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
+	if (is_kern_pte (pte)) {
+		return true;
+	}
 
 	/* 2. Resolve VA from the parent's page map level 4. */
 	parent_page = pml4_get_page (parent->pml4, va);
+	if (parent_page == NULL) {
+		return false;
+	}
 
-	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
-	 *    TODO: NEWPAGE. */
+	/* 3. Allocate new PAL_USER page for the child and set result to NEWPAGE. */
+	newpage = palloc_get_page (PAL_USER);
+	if (newpage == NULL) {
+		return false;
+	}
 
-	/* 4. TODO: Duplicate parent's page to the new page and
-	 *    TODO: check whether parent's page is writable or not (set WRITABLE
-	 *    TODO: according to the result). */
+	/* 4. Duplicate parent's page to the new page and
+	 *    check whether parent's page is writable or not (set WRITABLE
+	 *    according to the result). */
+	memcpy (newpage, parent_page, PGSIZE);
 
 	/* 5. Add new page to child's page table at address VA with WRITABLE
 	 *    permission. */
+	writable = is_writable (pte);
 	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: if fail to insert page, do error handling. */
+		/* 6. if fail to insert page, do error handling. */
+		palloc_free_page (newpage);
+		return false;
 	}
+
 	return true;
 }
 #endif
@@ -342,7 +344,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       this function. */
 
 /* __do_fork()가 thread_current()만 받은 것이 아니라,
-	process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
+   process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
 */
 static void
 __do_fork (void *aux) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -29,6 +29,12 @@ static bool load (char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
 
+// thread fork를 위한 구조체
+struct fork_aux {
+	struct thread *parent;
+	struct intr_frame parent_if;
+};
+
 struct fd_entry {
 	int fd;
 	struct file *file;
@@ -263,11 +269,39 @@ initd (void *f_name) {
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
+
+ /*
+	아래의 내용을 반영해야 함.
+
+	1. process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 준비
+	2. child_status 생성 및 children list 연결
+	3. thread_create()에 parent thread만 넘기는 대신 aux 구조체 넘기기
+	4. parent는 child가 복제 성공/실패를 알릴 때까지 기다리기
+	5. __do_fork()에서 aux를 받아 intr_frame 복사
+	6. child 쪽 if_.R.rax = 0 설정
+ */
 tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
+process_fork (const char *name, struct intr_frame *if_) {
 	/* Clone current thread to new thread.*/
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+	tid_t tid;
+	struct fork_aux *aux = malloc (sizeof *aux); // aux 구조체 할당
+
+	if (aux == NULL) {
+		return TID_ERROR;
+	}
+
+	aux->parent = thread_current (); // parent 저장
+
+	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
+
+	tid = thread_create (name, PRI_DEFAULT, __do_fork, aux); // thread_create에 aux 전달
+
+	if (tid == TID_ERROR) {
+		free(aux);
+		return TID_ERROR;
+	}
+
+	return tid;
 }
 
 #ifndef VM
@@ -306,17 +340,28 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  * Hint) parent->tf does not hold the userland context of the process.
  *       That is, you are required to pass second argument of process_fork to
  *       this function. */
+
+/* __do_fork()가 thread_current()만 받은 것이 아니라,
+	process_fork()에서 만든 struct fork_aux를 받는 함수로 바뀌어야 함.
+*/
 static void
 __do_fork (void *aux) {
-	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
+	struct fork_aux *fork_aux = aux; // void *aux를 struct fork_aux *로 해석하기 위해 형변환
+	struct intr_frame if_; // 인터럽트/시스템콜 진입 시점의 CPU 레지스터 상태를 담는 구조체 변수
+	struct thread *parent = fork_aux->parent;
 	struct thread *current = thread_current ();
-	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-	struct intr_frame *parent_if;
+	struct intr_frame *parent_if = &fork_aux->parent_if;
 	bool succ = true;
 
 	/* 1. Read the cpu context to local stack. */
+	/* fork()에서는 부모와 자식이 거의 같은 실행 상태에서 이어서 실행되어야 함.
+		그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+	if_.R.rax = 0; // 자식은 fork()의 반환값이 0이어야 함
+
+	// 사용한 메모리 해제
+	free (fork_aux);
+	fork_aux = NULL;
 
 	/* 2. Duplicate PT */
 	current->pml4 = pml4_create();
@@ -332,12 +377,6 @@ __do_fork (void *aux) {
 	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
 		goto error;
 #endif
-
-	/* TODO: Your code goes here.
-	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
-	 * TODO:       in include/filesys/file.h. Note that parent should not return
-	 * TODO:       from the fork() until this function successfully duplicates
-	 * TODO:       the resources of parent.*/
 
 	process_init ();
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -33,6 +33,7 @@ static void __do_fork (void *);
 struct fork_aux {
 	struct thread *parent;
 	struct intr_frame parent_if;
+	struct child_status *child_info;
 };
 
 struct fd_entry {
@@ -271,13 +272,38 @@ initd (void *f_name) {
  * TID_ERROR if the thread cannot be created. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
+
+	struct thread *parent = thread_current (); // 현재 스레드가 부모 스레드가 됨
+
 	/* process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 할당.*/
 	struct fork_aux *aux = malloc (sizeof *aux);
 	if (aux == NULL) {
 		return TID_ERROR;
 	}
 
-	aux->parent = thread_current (); // parent 저장
+	// 자식 상태 구조체 할당
+	struct child_status *cs = malloc (sizeof *cs);
+	if (cs == NULL) {
+		free (aux);
+		return TID_ERROR;
+	}
+
+	/* cs 초기화 */
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	cs->load_done = false;
+	cs->load_success = false;
+	cs->ref_cnt = 2;
+	sema_init (&cs->load_sema, 0);
+	sema_init (&cs->exit_sema, 0);
+
+	// 현재 실행 중인 부모 thread의 children 리스트에 새 자식 상태 cs를 등록
+	list_push_back (&parent->children, &cs->elem);
+
+	aux->child_info = cs; // child 저장
+
+	aux->parent = parent; // parent 저장
 
 	/* 부모의 syscall 진입 시점 레지스터 상태를 자식에게 넘기기 위해 aux에 복사한다. */
 	memcpy (&aux->parent_if, if_, sizeof *if_); // parent intr_frame 복사
@@ -285,7 +311,19 @@ process_fork (const char *name, struct intr_frame *if_) {
 	/* thread_create에 parent thread 대신 aux 전달. __do_fork()에서는 aux를 받아 intr_frame 복사 */
 	tid_t tid = thread_create (name, PRI_DEFAULT, __do_fork, aux);
 	if (tid == TID_ERROR) {
+		list_remove (&cs->elem);
+		free (cs);
 		free(aux);
+		return TID_ERROR;
+	}
+
+	// 부모, 자식의 tid 동기화
+	cs->tid = tid;
+	sema_down (&cs->load_sema);
+	if (!cs->load_success) {
+		list_remove (&cs->elem);
+		child_status_release (cs);
+		child_status_release (cs);
 		return TID_ERROR;
 	}
 
@@ -355,6 +393,8 @@ __do_fork (void *aux) {
 	struct intr_frame *parent_if = &fork_aux->parent_if;
 	bool succ = true;
 
+	current->child_info = fork_aux->child_info;
+
 	/* 1. Read the cpu context to local stack. */
 	/* fork()에서는 부모와 자식이 거의 같은 실행 상태에서 이어서 실행되어야 함.
 		그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
@@ -366,27 +406,49 @@ __do_fork (void *aux) {
 	fork_aux = NULL;
 
 	/* 2. Duplicate PT */
+	/* 주소 공간 복제 */
 	current->pml4 = pml4_create();
-	if (current->pml4 == NULL)
-		goto error;
+	if (current->pml4 == NULL) {
+		succ = false;
+		goto done;
+	}
+
 
 	process_activate (current);
 #ifdef VM
 	supplemental_page_table_init (&current->spt);
-	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
-		goto error;
+	if (!supplemental_page_table_copy (&current->spt, &parent->spt)) {
+		succ = false;
+		goto done;
+	}
 #else
-	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
-		goto error;
+	if (!pml4_for_each (parent->pml4, duplicate_pte, parent)) {
+		succ = false;
+		goto done;
+	}
 #endif
 
+	/* 자식 userprog 상태 초기화 */
 	process_init ();
 
+	/* 부모 fd table 복제 */
+	if (!process_duplicate_fds (current, parent)) {
+		succ = false;
+		goto done;
+	}
+
+	/* 성공/실패 결과를 child_status에 기록. 부모에게 fork 준비 완료를 알림 */
+done:
+	current->child_info->load_success = succ;
+	current->child_info->load_done = true;
+	sema_up (&current->child_info->load_sema); // sema_up()으로 부모 깨움
+
 	/* Finally, switch to the newly created process. */
-	if (succ)
-		do_iret (&if_);
-error:
-	thread_exit ();
+	if (succ) {
+		do_iret (&if_); // 성공이면 do_iret()
+	}
+
+	thread_exit (); // 실패면 thread_exit()
 }
 
 /* Switch the current execution context to the f_name.
@@ -463,6 +525,13 @@ process_exit (void) {
 		file_close (curr->exec_file);
 		curr->exec_file = NULL;
 	}
+
+	// 부모가 wait()에서 받을 수 있도록 현재 프로세스의 종료 상태를 기록
+	if (curr->child_info != NULL) {
+		curr->child_info->exit_status = curr->exit_status;
+		sema_up (&curr->child_info->exit_sema);
+	}
+
 	process_cleanup ();
 }
 
@@ -683,15 +752,16 @@ load (char *file_name, struct intr_frame *if_) {
 	}
 
 	/* Set up stack. */
-	if (!setup_stack (if_))
+	if (!setup_stack (if_)) {
 		goto done;
+	}
 
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
 	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_argv 끝부터 역순으로 넣는다.)
 	if_->rsp = USER_STACK;
-	
+
 	// 문자열들을 복사하여 실제 argv 배열에 역순으로 넣기
 	for (int i = argc - 1; i >= 0; i--) {
 		size_t len = strlen (tmp_argv[i]) + 1;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -26,13 +26,19 @@
 
 static void process_cleanup (void);
 static bool load (char *file_name, struct intr_frame *if_);
-static void initd (void *f_name);
+static void initd (void *aux);
 static void __do_fork (void *);
 
 // thread fork를 위한 구조체
 struct fork_aux {
 	struct thread *parent;
 	struct intr_frame parent_if;
+	struct child_status *child_info;
+};
+
+// fn_copy와 child_status *를 함께 넘기기 위한 작은 aux 구조체
+struct initd_aux {
+	char *file_name;
 	struct child_status *child_info;
 };
 
@@ -217,6 +223,9 @@ process_exit_with_status (int status) {
  * Notice that THIS SHOULD BE CALLED ONCE. */
 tid_t
 process_create_initd (const char *file_name) {
+	struct thread *parent = thread_current ();
+	struct child_status *cs;
+	struct initd_aux *aux;
 	char *fn_copy;
 	char *thread_name;
 	char *space;
@@ -226,6 +235,10 @@ process_create_initd (const char *file_name) {
 	 * Otherwise there's a race between the caller and load(). */
 	/* FILE_NAME의 복사본을 만드세요.
 	 * 그렇지 않으면 호출자와 load() 함수 사이에 경쟁 조건이 발생합니다. */
+
+	process_user_init (parent);
+
+	// fn_copy 준비
 	fn_copy = palloc_get_page (0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
@@ -233,38 +246,88 @@ process_create_initd (const char *file_name) {
 
 	thread_name = palloc_get_page (0);
 	if (thread_name == NULL) {
-		palloc_free_page(fn_copy);
+		palloc_free_page (fn_copy);
 		return TID_ERROR;
 	}
-		
 	strlcpy (thread_name, file_name, PGSIZE);
 
 	// copied_file_name의 첫 번째 인자만 추출하기
-	space = strchr(thread_name, ' ');
+	space = strchr (thread_name, ' ');
 	if (space != NULL) {
 		*space = '\0';
 	}
 
-	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (thread_name, PRI_DEFAULT, initd, fn_copy);
-	palloc_free_page (thread_name); // thread_name 메모리 해제
+	/* child_status 생성 및 parent->children에 등록 */
 
-	if (tid == TID_ERROR)
+	// 자식 상태 구조체 할당
+	cs = malloc (sizeof *cs);
+	if (cs == NULL) {
 		palloc_free_page (fn_copy);
+		palloc_free_page (thread_name);
+		return TID_ERROR;
+	}
+
+	/* cs 초기화 */
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	cs->load_done = false;
+	cs->load_success = false;
+	cs->ref_cnt = 2;
+	sema_init (&cs->load_sema, 0);
+	sema_init (&cs->exit_sema, 0);
+
+	aux = malloc (sizeof *aux);
+	if (aux == NULL) {
+		free (cs);
+		palloc_free_page (fn_copy);
+		palloc_free_page (thread_name);
+		return TID_ERROR;
+	}
+
+	// 전달하는 aux 안에 내용물 채우기
+	aux->file_name = fn_copy;
+	aux->child_info = cs; // aux에 child_status 연결
+
+	// 현재 thread의 자식 목록에 넣음
+	list_push_back (&parent->children, &cs->elem);
+
+	/* Create a new thread to execute FILE_NAME. */
+	tid = thread_create (thread_name, PRI_DEFAULT, initd, aux);
+	palloc_free_page (thread_name); // thread_name 메모리 해제
+	// (참고) aux 메모리는 initd() 안에서 file_name, child_info를 꺼낸 뒤 해제
+
+	if (tid == TID_ERROR) {
+		list_remove (&cs->elem);
+		free (aux);
+		free (cs);
+		palloc_free_page (fn_copy);
+		return TID_ERROR;
+	}
+
+	cs->tid = tid; // 자식 스레드 아이디에 새로 생성한 tid 할당
+
 	return tid;
 }
 
 /* A thread function that launches first user process. */
 static void
-initd (void *f_name) {
+initd (void *aux) {
 #ifdef VM
 	supplemental_page_table_init (&thread_current ()->spt);
 #endif
 
+	struct initd_aux *_aux = aux;
+	char *f_name = _aux->file_name;
+
+	/* 현재 thread의 종료 상태를 부모에게 알릴 child_status를 연결한다. */
+	thread_current ()->child_info = _aux->child_info;
+	free (_aux);
+
 	process_init ();
 
 	if (process_exec (f_name) < 0)
-		PANIC("Fail to launch initd\n");
+		PANIC ("Fail to launch initd\n");
 	NOT_REACHED ();
 }
 
@@ -322,7 +385,6 @@ process_fork (const char *name, struct intr_frame *if_) {
 	sema_down (&cs->load_sema);
 	if (!cs->load_success) {
 		list_remove (&cs->elem);
-		child_status_release (cs);
 		child_status_release (cs);
 		return TID_ERROR;
 	}
@@ -501,24 +563,43 @@ process_exec (void *f_name) {
  * 이 함수는 문제 2-2에서 구현될 예정입니다. 현재는
  * 아무런 동작도 하지 않습니다. */
 int
-process_wait (tid_t child_tid UNUSED) {
+process_wait (tid_t child_tid) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
 
-	// 커널 main thread가 살아있으면서 일정 시간동안 계속 잠들게 하기 위한 임시 무한루프 코드
-	for (int i = 0; i < 30; i++) {
-		timer_sleep (100);
+	struct child_status *cs;
+	int status;
+
+	cs = process_find_child (child_tid);
+	if (cs == NULL) {
+		return -1;
 	}
 
-	return -1;
+	// 이미 한 번 wait() 한 자식이면, 다시 기다릴 수 없으므로 실패 처리
+	if (cs->waited) {
+		return -1;
+	}
+
+	cs->waited = true;
+
+	/*  자식이 아직 종료되지 않은 동안 부모는 여기서 멈춤.
+	exit_sema는 부모와 자식이 공유하는 child_status 안에 존재. */
+	sema_down (&cs->exit_sema); // 부모는 cs->exit_sema 값이 0이면 잠들고, 1이면 깨어남.
+
+	status = cs->exit_status; // 자식의 종료상태를 cs 해제 전에 복사
+
+	list_remove (&cs->elem); // 부모의 children 리스트에서 자식의 child_status를 제거
+	child_status_release (cs);
+
+	return status;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
-	printf ("%s: exit(%d)\n", curr->name, curr->exit_status); 
+	printf ("%s: exit(%d)\n", curr->name, curr->exit_status);
 	process_close_all_files ();
 	if (curr->exec_file != NULL) {
 		file_allow_write (curr->exec_file);
@@ -530,6 +611,8 @@ process_exit (void) {
 	if (curr->child_info != NULL) {
 		curr->child_info->exit_status = curr->exit_status;
 		sema_up (&curr->child_info->exit_sema);
+		child_status_release (curr->child_info); // 자식 종료 시 자식 쪽 참조를 내려야 함.
+		curr->child_info = NULL;
 	}
 
 	process_cleanup ();

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -103,7 +103,7 @@ process_find_fd_entry (struct thread *t, int fd) {
 		return NULL;
 
 	for (e = list_begin (&t->fd_table); e != list_end (&t->fd_table);
-			e = list_next (e)) {
+	     e = list_next (e)) {
 		struct fd_entry *entry = list_entry (e, struct fd_entry, elem);
 		if (entry->fd == fd)
 			return entry;
@@ -161,7 +161,7 @@ process_duplicate_fds (struct thread *dst, struct thread *src) {
 
 	dst->next_fd = src->next_fd;
 	for (e = list_begin (&src->fd_table); e != list_end (&src->fd_table);
-			e = list_next (e)) {
+	     e = list_next (e)) {
 		struct fd_entry *src_entry = list_entry (e, struct fd_entry, elem);
 		struct fd_entry *dst_entry = malloc (sizeof *dst_entry);
 		if (dst_entry == NULL)
@@ -191,7 +191,7 @@ process_find_child (tid_t tid) {
 		return NULL;
 
 	for (e = list_begin (&cur->children); e != list_end (&cur->children);
-			e = list_next (e)) {
+	     e = list_next (e)) {
 		struct child_status *cs = list_entry (e, struct child_status, elem);
 		if (cs->tid == tid)
 			return cs;
@@ -335,7 +335,6 @@ initd (void *aux) {
  * TID_ERROR if the thread cannot be created. */
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
-
 	struct thread *parent = thread_current (); // 현재 스레드가 부모 스레드가 됨
 
 	/* process_fork()에서 parent intr_frame을 child에게 넘길 수 있게 aux 구조체 할당.*/
@@ -376,7 +375,7 @@ process_fork (const char *name, struct intr_frame *if_) {
 	if (tid == TID_ERROR) {
 		list_remove (&cs->elem);
 		free (cs);
-		free(aux);
+		free (aux);
 		return TID_ERROR;
 	}
 
@@ -449,7 +448,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 static void
 __do_fork (void *aux) {
 	struct fork_aux *fork_aux = aux; // void *aux를 struct fork_aux *로 해석하기 위해 형변환
-	struct intr_frame if_; // 인터럽트/시스템콜 진입 시점의 CPU 레지스터 상태를 담는 구조체 변수
+	struct intr_frame if_;           // 인터럽트/시스템콜 진입 시점의 CPU 레지스터 상태를 담는 구조체 변수
 	struct thread *parent = fork_aux->parent;
 	struct thread *current = thread_current ();
 	struct intr_frame *parent_if = &fork_aux->parent_if;
@@ -459,7 +458,7 @@ __do_fork (void *aux) {
 
 	/* 1. Read the cpu context to local stack. */
 	/* fork()에서는 부모와 자식이 거의 같은 실행 상태에서 이어서 실행되어야 함.
-		그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
+	    그래서 부모의 intr_frame을 자식 쪽 로컬 변수 if_에 복사 */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 	if_.R.rax = 0; // 자식은 fork()의 반환값이 0이어야 함
 
@@ -469,12 +468,11 @@ __do_fork (void *aux) {
 
 	/* 2. Duplicate PT */
 	/* 주소 공간 복제 */
-	current->pml4 = pml4_create();
+	current->pml4 = pml4_create ();
 	if (current->pml4 == NULL) {
 		succ = false;
 		goto done;
 	}
-
 
 	process_activate (current);
 #ifdef VM
@@ -543,7 +541,6 @@ process_exec (void *f_name) {
 	do_iret (&_if);
 	NOT_REACHED ();
 }
-
 
 /* Waits for thread TID to die and returns its exit status.  If
  * it was terminated by the kernel (i.e. killed due to an
@@ -662,20 +659,20 @@ process_activate (struct thread *next) {
 /* ELF types.  See [ELF1] 1-2. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* Ignore. */
-#define PT_LOAD    1            /* Loadable segment. */
-#define PT_DYNAMIC 2            /* Dynamic linking info. */
-#define PT_INTERP  3            /* Name of dynamic loader. */
-#define PT_NOTE    4            /* Auxiliary info. */
-#define PT_SHLIB   5            /* Reserved. */
-#define PT_PHDR    6            /* Program header table. */
-#define PT_STACK   0x6474e551   /* Stack segment. */
+#define PT_NULL    0          /* Ignore. */
+#define PT_LOAD    1          /* Loadable segment. */
+#define PT_DYNAMIC 2          /* Dynamic linking info. */
+#define PT_INTERP  3          /* Name of dynamic loader. */
+#define PT_NOTE    4          /* Auxiliary info. */
+#define PT_SHLIB   5          /* Reserved. */
+#define PT_PHDR    6          /* Program header table. */
+#define PT_STACK   0x6474e551 /* Stack segment. */
 
-#define PF_X 1          /* Executable. */
-#define PF_W 2          /* Writable. */
-#define PF_R 4          /* Readable. */
+#define PF_X 1 /* Executable. */
+#define PF_W 2 /* Writable. */
+#define PF_R 4 /* Readable. */
 
-#define MAX_ARGV	64		/* 최대 인자 개수 */		
+#define MAX_ARGV 64 /* 최대 인자 개수 */
 
 /* Executable header.  See [ELF1] 1-4 to 1-8.
  * This appears at the very beginning of an ELF binary. */
@@ -708,14 +705,14 @@ struct ELF64_PHDR {
 };
 
 /* Abbreviations */
-#define ELF ELF64_hdr
+#define ELF  ELF64_hdr
 #define Phdr ELF64_PHDR
 
 static bool setup_stack (struct intr_frame *if_);
 static bool validate_segment (const struct Phdr *, struct file *);
 static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes,
-		bool writable);
+                          uint32_t read_bytes, uint32_t zero_bytes,
+                          bool writable);
 
 /* Loads an ELF executable from FILE_NAME into the current thread.
  * Stores the executable's entry point into *RIP
@@ -730,7 +727,7 @@ load (char *file_name, struct intr_frame *if_) {
 	bool success = false;
 	int i;
 	size_t padding; // word-align
-	
+
 	/* Allocate and activate page directory. */
 	/* 해당 프로세스의 사용자 가상 주소 공간 */
 	t->pml4 = pml4_create ();
@@ -741,15 +738,15 @@ load (char *file_name, struct intr_frame *if_) {
 	process_activate (thread_current ());
 
 	// 토크나이저 사용
-	int64_t argc = 0;		// argv 개수
+	int64_t argc = 0;         // argv 개수
 	char *tmp_argv[MAX_ARGV]; // 임시 argv 배열
-	char *argv[MAX_ARGV + 1];	// argv 배열
-	char *save_ptr = NULL; // file_name의 마지막 주소 보관
+	char *argv[MAX_ARGV + 1]; // argv 배열
+	char *save_ptr = NULL;    // file_name의 마지막 주소 보관
 	char *token;
 
 	for (token = strtok_r (file_name, " ", &save_ptr); token != NULL; token = strtok_r (NULL, " ", &save_ptr)) {
 		// 메모리 오염 방어 코드
-		if (argc >= MAX_ARGV) { 
+		if (argc >= MAX_ARGV) {
 			goto done;
 		}
 
@@ -761,7 +758,7 @@ load (char *file_name, struct intr_frame *if_) {
 	if (argc == 0) {
 		goto done;
 	}
-	
+
 	/* Open executable file. */
 	file = filesys_open (tmp_argv[0]);
 	if (file == NULL) {
@@ -770,13 +767,8 @@ load (char *file_name, struct intr_frame *if_) {
 	}
 
 	/* Read and verify executable header. */
-	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
-			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
-			|| ehdr.e_type != 2
-			|| ehdr.e_machine != 0x3E // amd64
-			|| ehdr.e_version != 1
-			|| ehdr.e_phentsize != sizeof (struct Phdr)
-			|| ehdr.e_phnum > 1024) {
+	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr || memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 0x3E // amd64
+	    || ehdr.e_version != 1 || ehdr.e_phentsize != sizeof (struct Phdr) || ehdr.e_phnum > 1024) {
 		printf ("load: %s: error loading executable\n", file_name);
 		goto done;
 	}
@@ -794,43 +786,41 @@ load (char *file_name, struct intr_frame *if_) {
 			goto done;
 		file_ofs += sizeof phdr;
 		switch (phdr.p_type) {
-			case PT_NULL:
-			case PT_NOTE:
-			case PT_PHDR:
-			case PT_STACK:
-			default:
-				/* Ignore this segment. */
-				break;
-			case PT_DYNAMIC:
-			case PT_INTERP:
-			case PT_SHLIB:
-				goto done;
-			case PT_LOAD:
-				if (validate_segment (&phdr, file)) {
-					bool writable = (phdr.p_flags & PF_W) != 0;
-					uint64_t file_page = phdr.p_offset & ~PGMASK;
-					uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
-					uint64_t page_offset = phdr.p_vaddr & PGMASK;
-					uint32_t read_bytes, zero_bytes;
-					if (phdr.p_filesz > 0) {
-						/* Normal segment.
-						 * Read initial part from disk and zero the rest. */
-						read_bytes = page_offset + phdr.p_filesz;
-						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
-								- read_bytes);
-					} else {
-						/* Entirely zero.
-						 * Don't read anything from disk. */
-						read_bytes = 0;
-						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
-					}
-					if (!load_segment (file, file_page, (void *) mem_page,
-								read_bytes, zero_bytes, writable))
-						goto done;
+		case PT_NULL:
+		case PT_NOTE:
+		case PT_PHDR:
+		case PT_STACK:
+		default:
+			/* Ignore this segment. */
+			break;
+		case PT_DYNAMIC:
+		case PT_INTERP:
+		case PT_SHLIB:
+			goto done;
+		case PT_LOAD:
+			if (validate_segment (&phdr, file)) {
+				bool writable = (phdr.p_flags & PF_W) != 0;
+				uint64_t file_page = phdr.p_offset & ~PGMASK;
+				uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
+				uint64_t page_offset = phdr.p_vaddr & PGMASK;
+				uint32_t read_bytes, zero_bytes;
+				if (phdr.p_filesz > 0) {
+					/* Normal segment.
+					 * Read initial part from disk and zero the rest. */
+					read_bytes = page_offset + phdr.p_filesz;
+					zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE) - read_bytes);
+				} else {
+					/* Entirely zero.
+					 * Don't read anything from disk. */
+					read_bytes = 0;
+					zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
 				}
-				else
+				if (!load_segment (file, file_page, (void *) mem_page,
+				                   read_bytes, zero_bytes, writable))
 					goto done;
-				break;
+			} else
+				goto done;
+			break;
 		}
 	}
 
@@ -849,29 +839,28 @@ load (char *file_name, struct intr_frame *if_) {
 	for (int i = argc - 1; i >= 0; i--) {
 		size_t len = strlen (tmp_argv[i]) + 1;
 
-		if_->rsp -= len; // 넣을 만큼 빼주어야 함
-		memcpy ((void *)if_->rsp, tmp_argv[i], len); // start / end / sizeof
+		if_->rsp -= len;                              // 넣을 만큼 빼주어야 함
+		memcpy ((void *) if_->rsp, tmp_argv[i], len); // start / end / sizeof
 
 		// argv[] 에 스택의 주소값 저장
-		argv[i] = (char *)if_->rsp;	
+		argv[i] = (char *) if_->rsp;
 		// printf("if_->rsp === %x\n", if_->rsp); // debug
 	}
 
 	// padding으로 rsp를 8바이트 정렬
-	padding = if_->rsp % 8; // 8의 배수로 맞추기 위한 패딩 
-	if_->rsp -= padding; // 스택 넘버가 감소하는 방향으로 진행되기 때문
+	padding = if_->rsp % 8; // 8의 배수로 맞추기 위한 패딩
+	if_->rsp -= padding;    // 스택 넘버가 감소하는 방향으로 진행되기 때문
 
 	// NULL sentinel: argv[argc]가 null 포인터가 되도록 넣기
 	argv[argc] = NULL;
 
 	// 위에서 넣은 argv의 주소값을 8바이트 단위로 스택에 넣기.
-	for (int i = argc; i >= 0 ; i--) {
-
+	for (int i = argc; i >= 0; i--) {
 		// 넣을 만큼 빼주어야 함
-		if_->rsp -= sizeof(argv[i]);
+		if_->rsp -= sizeof (argv[i]);
 
 		// 스택에 argv[]의 인자의 주소값 저장
-		memcpy ((void *)if_->rsp, &argv[i], sizeof(argv[i]));
+		memcpy ((void *) if_->rsp, &argv[i], sizeof (argv[i]));
 		// printf("&argv[i] === %x\n", argv[i]); // debug
 	}
 
@@ -881,8 +870,8 @@ load (char *file_name, struct intr_frame *if_) {
 
 	// fake address 반환 - 문자열 "0"이 아닌 8바이트짜리 NULL 값을 넣어야 함.
 	void *fake_ret = NULL;
-	if_->rsp -= sizeof(fake_ret);
-	memcpy ((void *)if_->rsp, &fake_ret, sizeof(fake_ret));
+	if_->rsp -= sizeof (fake_ret);
+	memcpy ((void *) if_->rsp, &fake_ret, sizeof (fake_ret));
 
 	success = true;
 
@@ -960,7 +949,7 @@ static bool install_page (void *upage, void *kpage, bool writable);
  * or disk read error occurs. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+              uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs (upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
@@ -987,7 +976,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 		/* Add the page to the process's address space. */
 		if (!install_page (upage, kpage, writable)) {
-			printf("fail\n");
+			printf ("fail\n");
 			palloc_free_page (kpage);
 			return false;
 		}
@@ -1032,8 +1021,7 @@ install_page (void *upage, void *kpage, bool writable) {
 
 	/* Verify that there's not already a page at that virtual
 	 * address, then map our page there. */
-	return (pml4_get_page (t->pml4, upage) == NULL
-			&& pml4_set_page (t->pml4, upage, kpage, writable));
+	return (pml4_get_page (t->pml4, upage) == NULL && pml4_set_page (t->pml4, upage, kpage, writable));
 }
 #else
 /* From here, codes will be used after project 3.
@@ -1063,7 +1051,7 @@ lazy_load_segment (struct page *page, void *aux) {
  * or disk read error occurs. */
 static bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+              uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs (upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
@@ -1078,7 +1066,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		/* TODO: Set up aux to pass information to the lazy_load_segment. */
 		void *aux = NULL;
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
-					writable, lazy_load_segment, aux))
+		                                     writable, lazy_load_segment, aux))
 			return false;
 
 		/* Advance. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -209,6 +209,19 @@ child_status_release (struct child_status *cs) {
 		free (cs);
 }
 
+// 현재 프로세스가 부모로서 들고 있던 자식 목록을 비우고, 각 자식 상태에 대한 부모측의 참조를 해제하는 헬퍼 함수
+static void
+process_release_children (struct thread *t) { // t는 종료 중인 현재 thread
+	if (t == NULL || !process_list_initialized (&t->children))
+		return;
+
+	while (!list_empty (&t->children)) {
+		struct list_elem *e = list_pop_front (&t->children); // children 리스트에서 앞에서부터 제거
+		struct child_status *cs = list_entry (e, struct child_status, elem);
+		child_status_release (cs); // child_status에 대한 부모의 참조 카운트를 1 줄이기
+	}
+}
+
 void
 process_exit_with_status (int status) {
 	thread_current ()->exit_status = status;
@@ -603,6 +616,9 @@ process_exit (void) {
 		file_close (curr->exec_file);
 		curr->exec_file = NULL;
 	}
+
+	/* wait하지 않은 자식들의 parent-side child_status 참조 해제 */
+	process_release_children (curr);
 
 	// 부모가 wait()에서 받을 수 있도록 현재 프로세스의 종료 상태를 기록
 	if (curr->child_info != NULL) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -577,26 +577,25 @@ load (char *file_name, struct intr_frame *if_) {
 	off_t file_ofs;
 	bool success = false;
 	int i;
-	int order_size = strlen(file_name);
 	size_t padding; // word-align
 	
 	/* Allocate and activate page directory. */
 	/* 해당 프로세스의 사용자 가상 주소 공간 */
 	t->pml4 = pml4_create ();
-	if (t->pml4 == NULL)
-	goto done;
+	if (t->pml4 == NULL) {
+		goto done;
+	}
+
 	process_activate (thread_current ());
 
-	// file_name 을 파싱하는 함수가 이 단계 이전 어딘가에 들어가야 함.
 	// 토크나이저 사용
 	int64_t argc = 0;		// argv 개수
 	char *tmp_argv[MAX_ARGV]; // 임시 argv 배열
 	char *argv[MAX_ARGV + 1];	// argv 배열
-	char * save_ptr = NULL; // file_name의 마지막 주소 보관
+	char *save_ptr = NULL; // file_name의 마지막 주소 보관
 	char *token;
 
-	for (token = strtok_r(file_name, " ", &save_ptr); token != NULL; token = strtok_r(NULL, " ", &save_ptr)) {
-		
+	for (token = strtok_r (file_name, " ", &save_ptr); token != NULL; token = strtok_r (NULL, " ", &save_ptr)) {
 		// 메모리 오염 방어 코드
 		if (argc >= MAX_ARGV) { 
 			goto done;
@@ -607,7 +606,6 @@ load (char *file_name, struct intr_frame *if_) {
 	}
 
 	// filesys_open(tmp_argv[0])에서 초기화되지 않은 값을 쓰는 상황을 막기 위한 방어 코드
-	
 	if (argc == 0) {
 		goto done;
 	}
@@ -691,18 +689,15 @@ load (char *file_name, struct intr_frame *if_) {
 	/* Start address. */
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-
-	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_arvg 끝부터 역순으로 넣는다.) 
+	// 각 문자열의 주소를 스택에 오른쪽에서 왼쪽 순서로 push합니다.(tmp_argv 끝부터 역순으로 넣는다.)
 	if_->rsp = USER_STACK;
 	
 	// 문자열들을 복사하여 실제 argv 배열에 역순으로 넣기
-	for (int i = argc - 1; i >= 0 ; i--) {
+	for (int i = argc - 1; i >= 0; i--) {
 		size_t len = strlen (tmp_argv[i]) + 1;
 
 		if_->rsp -= len; // 넣을 만큼 빼주어야 함
-		memcpy((void *)if_->rsp, tmp_argv[i], len); // start / end / sizeof
+		memcpy ((void *)if_->rsp, tmp_argv[i], len); // start / end / sizeof
 
 		// argv[] 에 스택의 주소값 저장
 		argv[i] = (char *)if_->rsp;	
@@ -723,7 +718,7 @@ load (char *file_name, struct intr_frame *if_) {
 		if_->rsp -= sizeof(argv[i]);
 
 		// 스택에 argv[]의 인자의 주소값 저장
-		memcpy((void *)if_->rsp, &argv[i], sizeof(argv[i]));
+		memcpy ((void *)if_->rsp, &argv[i], sizeof(argv[i]));
 		// printf("&argv[i] === %x\n", argv[i]); // debug
 	}
 
@@ -734,7 +729,7 @@ load (char *file_name, struct intr_frame *if_) {
 	// fake address 반환 - 문자열 "0"이 아닌 8바이트짜리 NULL 값을 넣어야 함.
 	void *fake_ret = NULL;
 	if_->rsp -= sizeof(fake_ret);
-	memcpy((void *)if_->rsp, &fake_ret, sizeof(fake_ret));
+	memcpy ((void *)if_->rsp, &fake_ret, sizeof(fake_ret));
 
 	success = true;
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -172,9 +172,11 @@ syscall_handler (struct intr_frame *f) {
 
 		break;
 	}
-	case SYS_WAIT:// TODO: B                   /* Wait for a child process to die. */
-		f->R.rax = -1;
+	case SYS_WAIT: {                  /* Wait for a child process to die. */
+		tid_t child_tid = (tid_t) f->R.rdi; // 사용자 프로그램이 넘긴 pid 값
+		f->R.rax = process_wait (child_tid); // 자식 종료 상태를 syscall 반환값으로 저장
 		break;
+	}
 	case SYS_CREATE:// TODO: A                 /* Create a file. */
 		// 값 들어 오는 것 확인
 		// rdi로 제목 데이터 / rsi로 길이 데이터 들어옴.

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -148,7 +148,7 @@ syscall_handler (struct intr_frame *f) {
 	case SYS_EXIT:                   /* Terminate this process. */
 		process_exit_with_status((int) f->R.rdi);
 		break;
-	//
+	// 현재 실행중인 사용자 process를 복사해서 자식 process 생성
 	case SYS_FORK: {                   /* Clone current process. */
 		const char *thread_name = (const char *) f->R.rdi; // fork(const char *thread_name)의 첫 번째 인자
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -148,9 +148,14 @@ syscall_handler (struct intr_frame *f) {
 	case SYS_EXIT:                   /* Terminate this process. */
 		process_exit_with_status((int) f->R.rdi);
 		break;
-	case SYS_FORK:// TODO: B                   /* Clone current process. */
-		f->R.rax = -1;
-		break;	
+	//
+	case SYS_FORK: {                   /* Clone current process. */
+		const char *thread_name = (const char *) f->R.rdi; // fork(const char *thread_name)의 첫 번째 인자
+
+		user_check_string (thread_name);
+		f->R.rax = process_fork (thread_name, f); // fork() syscall 실패시 부모에게 -1 반환, 성공시 child tid 반환
+		break;
+	}
 	// 이미 실행 중인 user process가 exec()를 요청한 상황
 	case SYS_EXEC: {                   /* Switch current process. */
 		const char *cmd_line = (const char *) f->R.rdi; // exec(const char *file)의 첫 번째 인자


### PR DESCRIPTION
## 무엇을 변경했나요?

- SYS_WAIT가 process_wait()를 호출해 자식 종료 상태를 반환하도록 연결했습니다.
- process_wait()에서 자식 조회, 중복 wait 방지, exit_sema 대기, exit_status 반환 흐름을 구현했습니다.
- initd도 부모의 children 목록에서 추적되도록 child_status와 initd_aux를 구성했습니다.
- process_exit()에서 exit_status 기록, exit_sema 해제, child_status 참조 해제를 수행하도록 정리했습니다.
- child_status 필드 설명과 Pintos C 코드 포맷 정리를 별도 커밋으로 분리했습니다.

## 왜 변경했나요?

커널 main thread가 process_wait(process_create_initd(task))로 최초 user process 종료를 기다릴 수 있어야 하고, 사용자 프로그램의 wait syscall도 자식 종료 상태를 반환해야 합니다.

## 테스트

- [x] make -C pintos/userprog/build
- [x] wait 테스트 전체 통과
- [x] fork/exec 테스트 대부분 통과
- [ ] fork-read, fork-close, exec-read는 후속 FD/파일 실행 보호 작업 필요

## 참고

.gitattributes, .gitignore, .clang-format의 로컬 변경은 이번 PR에 포함하지 않았습니다.